### PR TITLE
autostart-fix

### DIFF
--- a/blade-common/pom.xml
+++ b/blade-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>blade</artifactId>
-        <version>4.20.0</version>
+        <version>4.21.0</version>
     </parent>
 
     <artifactId>blade-common</artifactId>

--- a/blade-common/src/main/java/com/backbase/oss/blade/tomcat/BladeHost.java
+++ b/blade-common/src/main/java/com/backbase/oss/blade/tomcat/BladeHost.java
@@ -155,11 +155,17 @@ public class BladeHost extends StandardHost {
                 throw new BladeStartException(FAILED_TO_START_WEB_APP + webApp.getName(), e);
             }
 
-            if (start) {
+            if (start || webApp.getName().startsWith("blade-webapp") || webApp.getName().startsWith("jolokia-war")) {
                 try {
                     ctx.start();
                 } catch (LifecycleException e) {
                     throw new BladeStartException(FAILED_TO_START_WEB_APP + webApp.getName(), e);
+                }
+            }else{
+                try {
+                    ctx.stop();
+                } catch (LifecycleException e) {
+                    e.printStackTrace();
                 }
             }
             long time = System.currentTimeMillis() - startTime;

--- a/blade-common/src/main/java/com/backbase/oss/blade/tomcat/BladeTomcat.java
+++ b/blade-common/src/main/java/com/backbase/oss/blade/tomcat/BladeTomcat.java
@@ -152,9 +152,10 @@ public class BladeTomcat extends Tomcat {
 
     public void autoStartStages() throws BladeStartException {
         for (Stage stage : blade.getStages()) {
-            if (stage.isAutoStart()) {
+            getHost().deploy(stage, classLoader);
+            /*if (stage.isAutoStart()) {
                 getHost().deploy(stage, classLoader);
-            }
+            }*/
         }
         updateStatus();
     }

--- a/blade-maven-plugin/pom.xml
+++ b/blade-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>blade</artifactId>
-        <version>4.20.0</version>
+        <version>4.21.0</version>
     </parent>
 
     <artifactId>blade-maven-plugin</artifactId>

--- a/blade-ui/pom.xml
+++ b/blade-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>blade</artifactId>
-        <version>4.20.0</version>
+        <version>4.21.0</version>
     </parent>
 
     <artifactId>blade-ui</artifactId>

--- a/blade-webapp/pom.xml
+++ b/blade-webapp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>blade</artifactId>
-        <version>4.20.0</version>
+        <version>4.21.0</version>
     </parent>
 
     <artifactId>blade-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.backbase.oss</groupId>
     <artifactId>blade</artifactId>
-    <version>4.20.0</version>
+    <version>4.21.0</version>
 
     <packaging>pom</packaging>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>blade</artifactId>
-        <version>4.20.0</version>
+        <version>4.21.0</version>
     </parent>
 
     <artifactId>tests</artifactId>


### PR DESCRIPTION
Details in the ticket -MAINT-12530
Because we are starting the whole thing with maven the classes are loaded by maven (BladeHost class), but in order to start apps that were not deployed initially we are doing it from blade-webapp which loads the BladeHost class (to call the deploy methos in it). Hence the class cast exception since they were loaded by two 2 different class loaders. 

This PR is for an alternative way where we all the apps to container and then stop it based on configuration. The downside of this approach will be that for a brief period of time, the app will try to start (any container added will attempt to start ) but then stopped immediately.
Now, since the app is already added to the context, we can start/stop like others.